### PR TITLE
refactor: Use Stripe events to trigger Moltin order status updates

### DIFF
--- a/api/handlers/authorize-order.js
+++ b/api/handlers/authorize-order.js
@@ -4,10 +4,19 @@ const moltin = new MoltinClient({
   client_id: process.env.MOLTIN_CLIENT_ID
 })
 
-module.exports = async ({ query: { orderId } }, res) => {
+module.exports = async (
+  {
+    body: {
+      data: {
+        object: { metadata }
+      }
+    }
+  },
+  res
+) => {
   try {
     res.send(
-      await moltin.post(`orders/${orderId}/payments`, {
+      await moltin.post(`orders/${metadata.order_id}/payments`, {
         gateway: 'manual',
         method: 'authorize'
       })

--- a/api/handlers/capture-order.js
+++ b/api/handlers/capture-order.js
@@ -5,15 +5,24 @@ const moltin = new MoltinClient({
   client_secret: process.env.MOLTIN_CLIENT_SECRET
 })
 
-module.exports = async ({ query: { orderId } }, res) => {
+module.exports = async (
+  {
+    body: {
+      data: {
+        object: { metadata }
+      }
+    }
+  },
+  res
+) => {
   try {
     const {
-      data: [{ id: transactionId }]
-    } = await moltin.get(`orders/${orderId}/transactions`)
+      data: [{ id: transaction_id }]
+    } = await moltin.get(`orders/${metadata.order_id}/transactions`)
 
     res.send(
       await moltin.post(
-        `orders/${orderId}/transactions/${transactionId}/capture`
+        `orders/${metadata.order_id}/transactions/${transaction_id}/capture`
       )
     )
   } catch ({ status }) {

--- a/api/handlers/create-intent.js
+++ b/api/handlers/create-intent.js
@@ -2,11 +2,12 @@ const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY)
 
 module.exports = async ({ body }, res) => {
   try {
-    const { amount, currency } = JSON.parse(body)
+    const { amount, currency, order_id } = JSON.parse(body)
 
     const { client_secret } = await stripe.paymentIntents.create({
       amount,
-      currency
+      currency,
+      metadata: { order_id }
     })
 
     res.status(201).json({ client_secret })

--- a/app/components/CheckoutForm.js
+++ b/app/components/CheckoutForm.js
@@ -8,34 +8,19 @@ function CheckoutForm({ stripe }) {
 
   async function onSubmit() {
     try {
-      await fetch(
-        `${
-          process.env.API_HOST
-        }/authorize/c71c078c-da11-43f8-8bbb-3dae11a9cc1d`,
-        {
-          method: 'POST'
-        }
-      )
-      const stripePaymentIntent = await fetch(
-        `${process.env.API_HOST}/intent`,
-        {
-          method: 'POST',
-          body: JSON.stringify({
-            amount: 9999,
-            currency: 'usd'
-          })
-        }
-      )
+      const order_id = '4b760a9e-29ef-4764-9b7e-2013931c3625'
+
+      const stripePaymentIntent = await fetch('/api/intent', {
+        method: 'POST',
+        body: JSON.stringify({
+          amount: 9999,
+          currency: 'usd',
+          order_id
+        })
+      })
       const { client_secret } = await stripePaymentIntent.json()
 
       await stripe.handleCardPayment(client_secret)
-
-      await fetch(
-        `${process.env.API_HOST}/capture/c71c078c-da11-43f8-8bbb-3dae11a9cc1d`,
-        {
-          method: 'POST'
-        }
-      )
     } catch (err) {
       setCheckoutError('There was a problem processing your order payment')
     }

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -3,7 +3,6 @@ require('dotenv').config()
 module.exports = {
   target: 'serverless',
   env: {
-    API_HOST: process.env.API_HOST || 'http://localhost:3000/api',
     STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY
   }
 }

--- a/now.json
+++ b/now.json
@@ -25,13 +25,13 @@
   ],
   "routes": [
     {
-      "src": "/api/authorize/(?<orderId>[^/]+)",
-      "dest": "/api/handlers/authorize-order.js?orderId=$orderId",
+      "src": "/api/authorize",
+      "dest": "/api/handlers/authorize-order.js",
       "methods": ["POST"]
     },
     {
-      "src": "/api/capture/(?<orderId>[^/]+)",
-      "dest": "/api/handlers/capture-order.js?orderId=$orderId",
+      "src": "/api/capture",
+      "dest": "/api/handlers/capture-order.js",
       "methods": ["POST"]
     },
     {


### PR DESCRIPTION
Rather than call the `authorize`, `capture` functions inside of the checkout component rely on Stripe's events emitted from the Payment Intent creation and success. 